### PR TITLE
Handle changes to countable in PHP 7.2+

### DIFF
--- a/src/JoblessQueue.php
+++ b/src/JoblessQueue.php
@@ -25,6 +25,10 @@ class JoblessQueue extends SqsQueue {
             'MaxNumberOfMessages' => 10
         ]);
 
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $response['Messages'] = (array)$response['Messages'];
+        }
+
         if (count($response['Messages']) > 0) {
 
             foreach ($response['Messages'] as $key => $message) {


### PR DESCRIPTION
We were developing fine on PHP 7.1 then deployed on PHP 7.2 and got this error:

~~~
[2018-12-09 23:59:52] production.ERROR: count(): Parameter must be an array or an object that implements Countable {"exception":"[object] (ErrorException(code: 0): count(): Parameter must be an array or an object that implements Countable at /home/ubuntu/v1.0.4/vendor/nollaversio/laravel-sqs-jobless/src/JoblessQueue.php:28)
~~~

This is an attempt at safely handling PHP 7.2 and above. If you know why $response['Messages'] might not be an array or might not be countable, I'm all ears. This got us by for now.